### PR TITLE
Security Fix + Retrocompability for old WordPress versions

### DIFF
--- a/pdf-print.php
+++ b/pdf-print.php
@@ -1639,10 +1639,19 @@ if ( ! class_exists( 'Pdfprnt_Buttons_Widget' ) ) {
 
 		function widget( $args, $instance ) {
 			global $pdfprnt_options, $pdfprnt_is_search_archive, $pdfprnt_is_custom_post_type;
-			$url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-			$url = esc_url( $url );
-			$buttons = '';
-            $target='_blank';
+
+			// Security check.
+			// Parsing url to extrapolate query parameter and sanitize them before printing them below.
+			$parse_request = wp_parse_url( $_SERVER['REQUEST_URI'] );
+			$path          = ( is_array( $parse_request ) && array_key_exists( 'path', $parse_request ) )
+				? $parse_request['path']
+				: '';
+			$query         = ( is_array( $parse_request ) && array_key_exists( 'query', $parse_request ) )
+				? '?' . rawurlencode( $parse_request['query'] )
+				: '';
+			$url           = esc_url( ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $path . $query );
+			$buttons       = '';
+			$target        = '_blank';
 
 			foreach ( array( 'pdf', 'print' ) as $button ) {
 				$instance[ $button . '_button_show' ] = ! empty( $instance[ $button . '_button_show' ] ) ? 1 : 0;

--- a/pdf-print.php
+++ b/pdf-print.php
@@ -955,7 +955,7 @@ if ( ! function_exists( 'pdfprnt_generate_template' ) ) {
 				if ( 0 == $pdfprnt_options['additional_fonts'] ) {
 					$content = pdfprnt_preg_replace( array( "font-family", "font:" ), $content );
 				}
-                if ( has_blocks( $content ) ) {
+                if ( function_exists( 'has_blocks' ) && has_blocks( $content ) ) {
                     $content = preg_replace( '/\s?<!--.*-->\s?/', "", $content );
                     $content = preg_replace('~<p></p>~', '', $content);
                 }


### PR DESCRIPTION
Hello,

I've noticed that the plugin has a potential security problem related to XSS and Reflected XSS.
This happen since the `$url` of the current page is created by calling `$_SERVER['REQUEST_URI']` without encoding back the uri query parameters before printing them alongiside the url in the html.

for example in a page with the pdf print link generated by the widget if you put an `?"><fake-div>` parameter at the end of the url you can eventually see the problem (XSS).
Same problem for Reflected XSS eg. `?792c"%2Fonclick%3Dalert%281%29%2F%2Fx%3D"x` will broke the html and add a onclick event on the a tag.

I've made this quick fix on my sites for the widget part that I'm currently use.

This could be probably improved and extended in all the parts of the plugin where the url is built in this way.

+

I've also made a minor check for retrocompability, since has_blocks function is not available in old WordPress versions.